### PR TITLE
Reduce Enum entries to one per field

### DIFF
--- a/src/openapi_coverage/schemas.py
+++ b/src/openapi_coverage/schemas.py
@@ -80,7 +80,7 @@ def coverable_parts(schema, schema_keys=None, refs=None):
 
         if "enum" in schema:
             coverage |= {
-                tuple(schema_keys + ["enum", i]) for i in range(len(schema["enum"]))
+                tuple(schema_keys + ["enum"])
             }
 
     else:

--- a/src/openapi_coverage/schemas.py
+++ b/src/openapi_coverage/schemas.py
@@ -79,9 +79,7 @@ def coverable_parts(schema, schema_keys=None, refs=None):
         # TODO cover minimum, maximum, pattern, etc.
 
         if "enum" in schema:
-            coverage |= {
-                tuple(schema_keys + ["enum"])
-            }
+            coverage |= {tuple(schema_keys + ["enum"])}
 
     else:
         raise ValueError(f"{type_} is not supported")


### PR DESCRIPTION
Report coverage per enum field instead of per enum value.