### PR TITLE
Add coverage markers for containers

### DIFF
--- a/src/openapi_coverage/har.py
+++ b/src/openapi_coverage/har.py
@@ -149,6 +149,5 @@ def cover_har(schema, har, url_map=None):
                     warnings.warn(
                         f"Unable to find schema for content type {content_type} - known types: {response_schema.keys()} in {method} {url}"
                     )
-    #import pdb; pdb.set_trace()
 
     return coverage

--- a/src/openapi_coverage/har.py
+++ b/src/openapi_coverage/har.py
@@ -42,6 +42,7 @@ def cover_har(schema, har, url_map=None):
         query_parameters = parse_qs(parsed_url.query)
         request_headers = _build_header_map(entry["request"]["headers"])
         operation = lookup(schema, parts)
+        coverage.add(tuple(parts))
 
         for i, parameter in enumerate(operation.get("parameters", [])):
             schema_keys = list((*parts, "parameters", i, "schema"))
@@ -148,5 +149,6 @@ def cover_har(schema, har, url_map=None):
                     warnings.warn(
                         f"Unable to find schema for content type {content_type} - known types: {response_schema.keys()} in {method} {url}"
                     )
+    #import pdb; pdb.set_trace()
 
     return coverage

--- a/src/openapi_coverage/paths.py
+++ b/src/openapi_coverage/paths.py
@@ -2,7 +2,7 @@
 
 from werkzeug.routing import Map, Rule
 
-from openapi_coverage.schemas import coverable_parts
+from .schemas import coverable_parts
 
 
 def build_url_map(schema):
@@ -30,6 +30,7 @@ def coverable_paths(schema):
     for path, operations in schema.get("paths", {}).items():
         for method, operation in operations.items():
             prefix = ["paths", path, method]
+            coverage.add(tuple(prefix))
             for i, parameter in enumerate(operation.get("parameters", [])):
                 coverage |= coverable_parts(
                     parameter["schema"],

--- a/src/openapi_coverage/schemas.py
+++ b/src/openapi_coverage/schemas.py
@@ -27,7 +27,8 @@ def coverable_parts(schema, schema_keys=None, refs=None):
     type_ = schema.get("type", "object")
 
     if type_ == "object":
-        coverage.add(tuple(schema_keys))
+        if schema_keys:
+            coverage.add(tuple(schema_keys))
         if "properties" in schema:
             for k in schema["properties"]:
                 coverage |= coverable_parts(
@@ -99,7 +100,8 @@ def cover_schema(schema, data, schema_keys=None):
             coverage.add(tuple(schema_keys))
 
     elif type_ == "object":
-        coverage.add(tuple(schema_keys))
+        if schema_keys:
+            coverage.add(tuple(schema_keys))
         if "properties" in schema:
             for k in schema["properties"]:
                 if data and k in data:

--- a/src/openapi_coverage/schemas.py
+++ b/src/openapi_coverage/schemas.py
@@ -21,13 +21,13 @@ def coverable_parts(schema, schema_keys=None, refs=None):
         if ref is not None:
             if ref in refs:
                 return coverage
-                # return {tuple(schema_keys)}
             refs.add(ref)
 
     schema_keys = schema_keys or []
     type_ = schema.get("type", "object")
 
     if type_ == "object":
+        coverage.add(tuple(schema_keys))
         if "properties" in schema:
             for k in schema["properties"]:
                 coverage |= coverable_parts(
@@ -99,6 +99,7 @@ def cover_schema(schema, data, schema_keys=None):
             coverage.add(tuple(schema_keys))
 
     elif type_ == "object":
+        coverage.add(tuple(schema_keys))
         if "properties" in schema:
             for k in schema["properties"]:
                 if data and k in data:

--- a/tests/test_openapi_coverage.py
+++ b/tests/test_openapi_coverage.py
@@ -82,7 +82,9 @@ def test_schemas(load_yaml, load_json, dereference):
 
     result = cover_schema(schema["components"]["schemas"]["Dog"], dog)
     assert result == {
+        ("allOf", 0),
         ("allOf", 0, "properties", "pet_type"),
+        ("allOf", 1),
         ("allOf", 1, "properties", "bark"),
     }
 
@@ -117,12 +119,15 @@ def test_replace_refs(load_yaml, dereference):
         )
     }
     assert result == {
+        ("components", "schemas", "Dog"),
+        ("components", "schemas", "Dog", "allOf", 1),
         ("components", "schemas", "Dog", "allOf", 1, "properties", "bark"),
         ("components", "schemas", "Dog", "allOf", 1, "properties", "breed"),
+        ("components", "schemas", "Pet"),
         ("components", "schemas", "Pet", "properties", "pet_type"),  # from allOf $ref
     }
 
 
 def test_coverable_paths(load_yaml, dereference):
     schema = dereference(load_yaml("schemas/petstore.yaml"))
-    assert 7 == len(coverable_paths(schema))
+    assert 12 == len(coverable_paths(schema))


### PR DESCRIPTION
To be able to track APIs and components, we need to add a coverage of the elements and paths themselves, not just the properties